### PR TITLE
timeouts for windows

### DIFF
--- a/src/test.zig
+++ b/src/test.zig
@@ -1,0 +1,33 @@
+const std = @import("std");
+const serial = @import("serial.zig");
+
+test "com0com loopback" {
+    var sp1 = try std.fs.cwd().openFile("\\\\.\\COM10", .{ .mode = .read_write });
+    defer sp1.close();
+    var sp2 = try std.fs.cwd().openFile("\\\\.\\COM11", .{ .mode = .read_write });
+    defer sp2.close();
+
+    try serial.configureSerialPort(sp1, .{
+        .baud_rate = 115200,
+        .handshake = .none,
+        .parity = .none,
+        .stop_bits = .one,
+        .word_size = .eight,
+    });
+    try serial.configureSerialPort(sp2, .{
+        .baud_rate = 115200,
+        .handshake = .none,
+        .parity = .none,
+        .stop_bits = .one,
+        .word_size = .eight,
+    });
+
+    serial.flushSerialPort(sp1, true, true) catch {};
+    serial.flushSerialPort(sp2, true, true) catch {};
+    const hello = "hello";
+    _ = try sp1.write(hello);
+    var buf = [_]u8{0} ** 100;
+    _ = try sp2.read(&buf);
+    std.debug.print("read: {s}\n", .{buf[0..]});
+    try std.testing.expectEqualStrings(hello, buf[0..]);
+}


### PR DESCRIPTION
Settings timeouts for windows to prevent hanging when less bytes are available than the length of the provided buffer.

Default windows behaviour waits until it can fill the provided buffer. With this, the default timeout of zero mimics the posix way of doing things and immediately returns the serial buffer, even if there are no bytes available. Any non-zero timeout will wait until either the buffer is filled, or the timeout is reached.