### PR TITLE
Using CSIZE, making windows follow suite

### DIFF
--- a/src/test.zig
+++ b/src/test.zig
@@ -12,14 +12,14 @@ test "com0com loopback" {
         .handshake = .none,
         .parity = .none,
         .stop_bits = .one,
-        .word_size = .eight,
+        .word_size = .CS8,
     });
     try serial.configureSerialPort(sp2, .{
         .baud_rate = 115200,
         .handshake = .none,
         .parity = .none,
         .stop_bits = .one,
-        .word_size = .eight,
+        .word_size = .CS8,
     });
 
     serial.flushSerialPort(sp1, true, true) catch {};


### PR DESCRIPTION
Posix support for all the wordsizes are all over the place. Directly connecting CSIZE to WordSize to avoid having a bunch of special cases.

Modeled windows after CSIZE, because windows was the oddball out.